### PR TITLE
Add cloud tag

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -31,7 +31,7 @@ changelog=0.2.0 2019-10-18
     * Update bundled libraries 
 
 # Tags are comma separated with spaces allowed
-tags=python, BigQuery, Google Cloud
+tags=cloud, BigQuery, Google Cloud
 
 homepage=https://github.com/smandaric/bigquerylayers
 category=Database


### PR DESCRIPTION
There are already some plugins listed unter this tag: https://plugins.qgis.org/plugins/tags/cloud/ 
and it will be good for the discoverability of this plugin